### PR TITLE
New questions from Civil Docketing Statement

### DIFF
--- a/docassemble/MassAppealsCourt/data/questions/appeals-basic-questions.yml
+++ b/docassemble/MassAppealsCourt/data/questions/appeals-basic-questions.yml
@@ -258,9 +258,11 @@ help:
     If you are responding to a case or court papers someone else filed, you are
     the "Defendant" or the "Respondent."
 ---
-id: appeals docket numbers
+id: appeals docket number
 question: |
-  Do you have an Appeals Court docket number for this case?
+  What is the docket number for your Appeals Court case? 
 subquestion: |
   This should _not_ be the docket number for the trial court case.
-yesno: docket_numbers.there_are_any
+fields:
+  - no label: appeals_docket_number
+    required: True

--- a/docassemble/MassAppealsCourt/data/questions/appeals-basic-questions.yml
+++ b/docassemble/MassAppealsCourt/data/questions/appeals-basic-questions.yml
@@ -224,3 +224,38 @@ code: |
       email_success = send_email(to=email_to_use, template=email_to_court_template, task='send email', attachments=final_form_to_file)
     mark_task_as_performed('send email')
   sent_email_to_court = True
+---
+id: user role
+question: |
+  Did you file the first forms in the trial court, or did you respond to a case
+  that someone else started?
+fields:
+  - no label: user_ask_role
+    datatype: radio
+    choices:
+      - I started the case: plaintiff
+      - I responded to the case: defendant
+  - note: |
+      Okay, you are the **Plaintiff** or Petitioner in the trial court. The other
+      side is the **Defendant** or Respondent.
+    show if:
+      variable: user_ask_role
+      is: "plaintiff"
+  - note: |
+      Okay, you are the **Defendant** or Respondent in the trial court. The other
+      side is the **Plaintiff** or Petitioner.
+    show if:
+      variable: user_ask_role
+      is: "defendant"
+help:
+  label: |
+    How do I know?
+  content: |
+    We need to know if you are the "Plaintiff" or the "Defendant" in your
+    trial court case.
+
+    If you are the first person to file a form in the case, you are the
+    "Plaintiff" or the "Petitioner."
+
+    If you are responding to a case or court papers someone else filed, you are
+    the "Defendant" or the "Respondent."

--- a/docassemble/MassAppealsCourt/data/questions/appeals-basic-questions.yml
+++ b/docassemble/MassAppealsCourt/data/questions/appeals-basic-questions.yml
@@ -198,6 +198,7 @@ fields:
   - My preferred language is: user_preferred_language
     show if: user_needs_interpreter
 ---
+id: Appeals send to court
 comment: |
   Send to court code--tweaked slightly for MAC
 need:
@@ -227,7 +228,7 @@ code: |
 ---
 id: user role
 question: |
-  Did you file the first forms in the trial court, or did you respond to a case
+  In the trial court, did you file the first forms, or did you respond to a case
   that someone else started?
 fields:
   - no label: user_ask_role
@@ -251,11 +252,15 @@ help:
   label: |
     How do I know?
   content: |
-    We need to know if you are the "Plaintiff" or the "Defendant" in your
-    trial court case.
-
     If you are the first person to file a form in the case, you are the
     "Plaintiff" or the "Petitioner."
 
     If you are responding to a case or court papers someone else filed, you are
     the "Defendant" or the "Respondent."
+---
+id: appeals docket numbers
+question: |
+  Do you have an Appeals Court docket number for this case?
+subquestion: |
+  This should _not_ be the docket number for the trial court case.
+yesno: docket_numbers.there_are_any


### PR DESCRIPTION
Some questions that Quinten had written and I had added in [the Civil Docketing Statement](https://github.com/SuffolkLITLab/docassemble-AppealsCivilDocketingStatement/blob/1e1cb32e4052711279f6fdbe767cb80746c64166/docassemble/AppealsCivilDocketingStatement/data/questions/civil_docketing_statement.yml#L786); one about plaintiffs and defendants, and one clarifying the difference between the appeals court docket number and the trial court docket number. 

When talking with @miabonardi and Rebecca about the Civil Docketing Statement though, Mia brought up that Appeals Court cases shouldn't have multiple docket numbers. The question in [basic_questions](https://github.com/SuffolkLITLab/docassemble-MAVirtualCourt/blob/7124077fa400e67febea83ed524f5c6764d3a7b5/docassemble/MAVirtualCourt/data/questions/basic-questions.yml#L797) that this change will prompt for asks for multiple. Not sure how to fix correctly, but we could:
* use the [docket_number](https://github.com/SuffolkLITLab/docassemble-MAVirtualCourt/blob/7124077fa400e67febea83ed524f5c6764d3a7b5/docassemble/MAVirtualCourt/data/questions/basic-questions.yml#L789) variable in all Appeals Court forms instead
* make a new question in this repo that asks for the docket number in an appeals specific way. 

Not sure how to proceed there though. 

This PR should contain the `new_plaintiff_qs` branch too. 