### PR TITLE
Only validate BBO numbers in Appeals

### DIFF
--- a/docassemble/MassAppealsCourt/data/questions/appeals-basic-questions.yml
+++ b/docassemble/MassAppealsCourt/data/questions/appeals-basic-questions.yml
@@ -1,4 +1,7 @@
 ---
+modules:
+  - .ma_appeals_specific_logic
+---
 code: |
   courts[0] = macourts.matching_appeals_court("")
 ---
@@ -266,3 +269,14 @@ subquestion: |
 fields:
   - no label: appeals_docket_number
     required: True
+---
+id: attorney bbo
+question: |
+  What is ${ attorneys[i].possessive('BBO number') }?
+fields:
+  - BBO: attorneys[i].id_number
+    required: True
+    validate: is_bbo_number
+auto terms:
+  BBO number: |
+    Board of Bar Overseers, a regulatory board that tracks lawyers. All Massachusetts lawyers will have this number.

--- a/docassemble/MassAppealsCourt/ma_appeals_specific_logic.py
+++ b/docassemble/MassAppealsCourt/ma_appeals_specific_logic.py
@@ -1,0 +1,19 @@
+"""Logic / code that is specific to the Massachusetts Appeals Court"""
+
+from docassemble.base.util import validation_error
+
+def is_bbo_number(entered_bbo_number: str) -> bool:
+    """All MA BBO numbers should be exactly 6 digits.
+    Could have leading 0's, so can't just have an integer between 0 and 999999
+    """ 
+    if len(entered_bbo_number) != 6:
+        validation_error('The BBO number must be exactly 6 digits')
+
+    if entered_bbo_number.isdigit():
+        return True
+
+    for letter in entered_bbo_number:
+        if not letter.isdigit():
+            validation_error('"{}" is not a digit: the BBO number should be 6 numbers'.format(letter))
+    return False
+    


### PR DESCRIPTION
Validates BBO here, instead of in https://github.com/SuffolkLITLab/docassemble-ALMassachusetts/pull/1.  

Related PRs and issues:
* https://github.com/SuffolkLITLab/docassemble-AppealsCivilDocketingStatement/issues/14
* https://github.com/SuffolkLITLab/docassemble-AssemblyLine/pull/23
* https://github.com/SuffolkLITLab/docassemble-AppealsCivilDocketingStatement/pull/19