### PR TITLE
Send to court aldoc

### DIFF
--- a/docassemble/MassAppealsCourt/data/questions/appeals-basic-questions.yml
+++ b/docassemble/MassAppealsCourt/data/questions/appeals-basic-questions.yml
@@ -1,5 +1,6 @@
 ---
 modules:
+  - docassemble.AssemblyLine.al_general
   - .ma_appeals_specific_logic
 ---
 code: |
@@ -201,22 +202,19 @@ need:
   - court_email
   - should_cc_user
 code: |
-  if 'dev' in get_config('url root') or 'test' in get_config('url root'):
-    email_to_use = "massaccess@suffolk.edu"
-  else:
+  if will_send_to_real_court():
     email_to_use = court_email
-  
-  # temporary for testing
-  # email_to_use = "massaccess@suffolk.edu"
+  else:
+    email_to_use = dev_email_to_use
   
   if task_not_yet_performed('send email'):
     log("Court email is " + court_email)
     email_success = False
     if should_cc_user:
-      log('Sending email to ' + email_to_use + ' and ccing ' + cc_email + ' for ' + str(users))
+      log('Sending email to {} and ccing {} for {}'.format(email_to_use, cc_email, str(users)))
       email_success = send_email(to=email_to_use, template=email_to_court_template, task='send email', cc=cc_email, attachments=final_form_to_file) # True # until we're ready to turn this on
     else:
-      log('Sending email to ' + email_to_use + ' and no cc ' + ' for ' + str(users))
+      log('Sending email to {} and no cc for {}'.format(email_to_use, str(users)))
       email_success = send_email(to=email_to_use, template=email_to_court_template, task='send email', attachments=final_form_to_file)
     mark_task_as_performed('send email')
   sent_email_to_court = True

--- a/docassemble/MassAppealsCourt/data/questions/appeals-basic-questions.yml
+++ b/docassemble/MassAppealsCourt/data/questions/appeals-basic-questions.yml
@@ -133,7 +133,7 @@ question: |
   Final Review With Cover Page
 subquestion: |
   
-  Below is your ${comma_and_list(download_titles)} document with the 
+  Below is your ${comma_and_list(al_download_titles)} document with the
   cover page that we will deliver to ${courts[0]}.
   
   Click "Back" if you need to make any changes.  
@@ -148,8 +148,8 @@ subquestion: |
   
   Here is what the clerk at ${courts} will get:
 
-  ${ final_form_to_be_filed } 
-  [:file-download: Download this form with cover page](${final_form_to_be_filed.url_for(attachment=True)})
+  ${ al_final_form_to_file }
+  [:file-download: Download this form with cover page](${final_form_to_file.url_for(attachment=True)})
 
   % if found_email:
   We will deliver it securely. Please allow up to 15 minutes for the email to
@@ -212,10 +212,10 @@ code: |
     email_success = False
     if should_cc_user:
       log('Sending email to {} and ccing {} for {}'.format(email_to_use, cc_email, str(users)))
-      email_success = send_email(to=email_to_use, template=email_to_court_template, task='send email', cc=cc_email, attachments=final_form_to_be_filed) # True # until we're ready to turn this on
+      email_success = send_email(to=email_to_use, template=email_to_court_template, task='send email', cc=cc_email, attachments=al_final_form_to_file) # True # until we're ready to turn this on
     else:
       log('Sending email to {} and no cc for {}'.format(email_to_use, str(users)))
-      email_success = send_email(to=email_to_use, template=email_to_court_template, task='send email', attachments=final_form_to_be_filed)
+      email_success = send_email(to=email_to_use, template=email_to_court_template, task='send email', attachments=al_final_form_to_file)
     mark_task_as_performed('send email')
   sent_email_to_court = True
 ---

--- a/docassemble/MassAppealsCourt/data/questions/appeals-basic-questions.yml
+++ b/docassemble/MassAppealsCourt/data/questions/appeals-basic-questions.yml
@@ -148,8 +148,8 @@ subquestion: |
   
   Here is what the clerk at ${courts} will get:
 
-  ${ final_form_to_file } 
-  [:file-download: Download this form with cover page](${final_form_to_file.url_for(attachment=True)})
+  ${ final_form_to_be_filed } 
+  [:file-download: Download this form with cover page](${final_form_to_be_filed.url_for(attachment=True)})
 
   % if found_email:
   We will deliver it securely. Please allow up to 15 minutes for the email to
@@ -212,10 +212,10 @@ code: |
     email_success = False
     if should_cc_user:
       log('Sending email to {} and ccing {} for {}'.format(email_to_use, cc_email, str(users)))
-      email_success = send_email(to=email_to_use, template=email_to_court_template, task='send email', cc=cc_email, attachments=final_form_to_file) # True # until we're ready to turn this on
+      email_success = send_email(to=email_to_use, template=email_to_court_template, task='send email', cc=cc_email, attachments=final_form_to_be_filed) # True # until we're ready to turn this on
     else:
       log('Sending email to {} and no cc for {}'.format(email_to_use, str(users)))
-      email_success = send_email(to=email_to_use, template=email_to_court_template, task='send email', attachments=final_form_to_file)
+      email_success = send_email(to=email_to_use, template=email_to_court_template, task='send email', attachments=final_form_to_be_filed)
     mark_task_as_performed('send email')
   sent_email_to_court = True
 ---

--- a/docassemble/MassAppealsCourt/data/questions/appeals-basic-questions.yml
+++ b/docassemble/MassAppealsCourt/data/questions/appeals-basic-questions.yml
@@ -125,6 +125,9 @@ validation code: |
       (not showifdef('users[0].other_contact_method')):
     validation_error(word("You need to provide at least one other contact method."))
 ---
+code: |
+  all_final_forms_combined = al_final_form_to_file.as_pdf(key='final')
+---
 need:
   - comments_to_clerk
   - package_version_number
@@ -148,8 +151,8 @@ subquestion: |
   
   Here is what the clerk at ${courts} will get:
 
-  ${ al_final_form_to_file }
-  [:file-download: Download this form with cover page](${final_form_to_file.url_for(attachment=True)})
+  ${ all_final_forms_combined }
+  [:file-download: Download this form with cover page](${all_final_forms_combined.url_for(attachment=True)})
 
   % if found_email:
   We will deliver it securely. Please allow up to 15 minutes for the email to
@@ -212,10 +215,12 @@ code: |
     email_success = False
     if should_cc_user:
       log('Sending email to {} and ccing {} for {}'.format(email_to_use, cc_email, str(users)))
-      email_success = send_email(to=email_to_use, template=email_to_court_template, task='send email', cc=cc_email, attachments=al_final_form_to_file) # True # until we're ready to turn this on
+      email_success = send_email(to=email_to_use, template=email_to_court_template, task='send email', 
+                                 cc=cc_email, attachments=al_final_form_to_file.as_pdf_list(key='final')) # True # until we're ready to turn this on
     else:
       log('Sending email to {} and no cc for {}'.format(email_to_use, str(users)))
-      email_success = send_email(to=email_to_use, template=email_to_court_template, task='send email', attachments=al_final_form_to_file)
+      email_success = send_email(to=email_to_use, template=email_to_court_template, task='send email', 
+                                 attachments=al_final_form_to_file.as_pdf_list(key='final'))
     mark_task_as_performed('send email')
   sent_email_to_court = True
 ---


### PR DESCRIPTION
Related to https://github.com/SuffolkLITLab/docassemble-AssemblyLine/pull/46, should be merged after. 

The Appeals code needs some more refactors, but for this is good for the moment.

@miabonardi, the Motion to Stay General will have to just remove these lines of `id: download forms`: 
```
 % for file in final_form_to_file:
 ...
 % endfor
 ```
since they duplicate the html list below.