### PR TITLE
Correct Blockquote

### DIFF
--- a/docassemble/MassAppealsCourt/data/questions/efiling.yml
+++ b/docassemble/MassAppealsCourt/data/questions/efiling.yml
@@ -27,7 +27,9 @@ subquestion: |
   % if defined("comments_to_clerk") and comments_to_clerk:
   We will also include these comments to the clerk:
 
-  > ${ comments_to_clerk }
+  <blockquote class="blockquote">
+  ${ comments_to_clerk }
+  </blockquote>
   % endif
 
   Click "Send to court" below to deliver the forms.

--- a/docassemble/MassAppealsCourt/data/questions/efiling.yml
+++ b/docassemble/MassAppealsCourt/data/questions/efiling.yml
@@ -28,7 +28,7 @@ subquestion: |
   We will also include these comments to the clerk:
 
   <blockquote class="blockquote">
-  ${ comments_to_clerk }
+  ${ comments_to_clerk.replace("\n", "<br/>") }
   </blockquote>
   % endif
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.MassAppealsCourt',
       url='https://corutformsonline.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.MAVirtualCourt>=1.0.22'],
+      install_requires=['docassemble.MassAccess'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/MassAppealsCourt/', package='docassemble.MassAppealsCourt'),
      )


### PR DESCRIPTION
Markdown block quotes break on multi-line inputs with an extra space between
them, something someone might type in the area text field on the page before.
We additionally replace new lines in the comments with `<br>` so they show up
correctly in the webpage.

Additionally, we were still using `install_requires` on MAVirtualCourt instead of
MassAccess. This change shouldn't change anything in the YAML files, checked
that there are no references to MAVirtualCourt.